### PR TITLE
update to subindex@0.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
   "dependencies": {
     "unique-stream": "0.0.2",
     "through": "~2.3.4",
-    "subindex": "0.0.2"
+    "subindex": "0.0.4"
   }
 }


### PR DESCRIPTION
use latest version of subindex, which removes byteup dependency.

please publish a new version of level-queryengine
