### PR TITLE
docs: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Example Usage with the [jsonquery-engine](https://github.com/eugeneware/jsonquer
 
 ``` js
 var levelQuery = require('level-queryengine'),
-    jsonqqueryEngine = require('jsonquery-engine'),
+    jsonqueryEngine = require('jsonquery-engine'),
     pairs = require('pairs'),
     levelup = require('levelup'),
     db = levelQuery(levelup('my-db'));


### PR DESCRIPTION
changed `jsonqqueryEngine` to `jsonqueryEngine`